### PR TITLE
bugfix conditional in if statement

### DIFF
--- a/share/chruby/auto.fish
+++ b/share/chruby/auto.fish
@@ -32,7 +32,7 @@ function chruby_auto --on-event fish_prompt
 
   test $status_code = 1; and return 1
 
-  if test -z "$found"; and test -n "$RUBY_AUTO_VERSION"
+  if begin; test -z "$found"; and test -n "$RUBY_AUTO_VERSION"; end
     chruby_reset
     set -e RUBY_AUTO_VERSION
   end


### PR DESCRIPTION
From the fish docs ( http://ridiculousfish.com/shell/user_doc/html/commands.html#if ):
In order to use the exit status of multiple commands as the condition of an if block, use begin; ...; end and the short circuit commands and and or.
