### PR TITLE
Work around fish-shell/fish-shell#1168

### DIFF
--- a/share/chruby/chruby.fish
+++ b/share/chruby/chruby.fish
@@ -118,13 +118,13 @@ end
 function chruby
   set -l external_commands '-h' '--help' '-V' '--version'
 
-  if test -z "$argv"
-    bchruby 'chruby'
-  else if echo $external_commands | grep -q -e "$argv[1]"
+  if echo $external_commands | grep -q -e "$argv[1]"
     bchruby 'chruby' $argv
     if test "$argv[1]" = '-V' -o "$argv[1]" = '--version'
       echo 'chruby-fish:' $CHRUBY_FISH_VERSION
     end
+  else if test -z "$argv"
+    bchruby 'chruby'
   else if test $argv[1] = 'system'
     chruby_reset
   else if bchruby 'chruby' $argv


### PR DESCRIPTION
Current version of Fish does not like pipelines in an else if statement. See fish-shell/fish-shell#1168 for more info.

Version info:

```
➜  fish --version
fish, version 2.1.0
➜  chruby --version
chruby: 0.3.8
chruby-fish: 0.5.4
```

/cc @tduffield @seth
