### PR TITLE
Supress PATH warnings

### DIFF
--- a/share/chruby/chruby.fish
+++ b/share/chruby/chruby.fish
@@ -74,7 +74,7 @@ function chruby_reset
     end
   end
 
-  set -gx PATH (echo $ch_path | tr : '\n')
+  set -gx PATH (echo $ch_path | tr : '\n') 2>/dev/null
 
   set -l unset_vars RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT
   for i in (seq (count $unset_vars))


### PR DESCRIPTION
Not sure if this is a good idea but this should prevent `set` warnings (#14):

```
set: Warning: path component /path/to/ruby-x.y.z/lib/ruby/gems/x.y.z/bin may not be valid in PATH.
set: No such file or directory
```