### PR TITLE
Odd behavior when using env call

### DIFF
--- a/share/chruby/chruby.fish
+++ b/share/chruby/chruby.fish
@@ -44,14 +44,14 @@ function bchruby
   end
 
   set bash_path (echo $PATH | tr ' ' ':')
-  env - bash -lc "export HOME=$HOME           \
-                         PREFIX=$PREFIX       \
-                         PATH=$bash_path      \
-                         RUBY_ROOT=$RUBY_ROOT \
-                         GEM_HOME=$GEM_HOME   \
-                         GEM_ROOT=$GEM_ROOT   \
-                         GEM_PATH=$GEM_PATH;  \
-                  source $CHRUBY_ROOT/share/chruby/chruby.sh; $argv"
+  bash -lc "export HOME=$HOME           \
+                   PREFIX=$PREFIX       \
+                   PATH=$bash_path      \
+                   RUBY_ROOT=$RUBY_ROOT \
+                   GEM_HOME=$GEM_HOME   \
+                   GEM_ROOT=$GEM_ROOT   \
+                   GEM_PATH=$GEM_PATH;  \
+            source $CHRUBY_ROOT/share/chruby/chruby.sh; $argv"
 end
 
 # Define RUBIES variable with paths to installed ruby versions.


### PR DESCRIPTION
I get the feeling something is up with my local configuration but I thought I'd open a PR to discuss the issue I've been having now that I've narrowed it down a bit... If you can provide any insight, I'd appreciate it!

When calling `chruby` I've been getting errors like `chruby: unknown Ruby: 2.1.1`, even though I have the version of Ruby that it's complaining about. For example, I'd get output like:

```
λ chruby
chruby: unknown Ruby: 2.1.1
 * ruby-2.1.1
   ruby-2.1.3
   ruby-2.1.8
   ruby-2.3.0
```

Whenever I `cd` to a directory with a `.ruby-version` file I would get

```
chruby: unknown Ruby: 2.1.1
chruby: unknown Ruby: 2.1.1
```

Everything has been working absolutely fine other than this error. I can switch rubies as expected. I've simply ignored it for a while.

Today I decided to try and see if I could figure out the problem. It turns out I was able to reduce it to the following:

```
λ bash -lc "source /usr/local/share/chruby/chruby.sh"
λ env - bash -lc "source /usr/local/share/chruby/chruby.sh"
chruby: unknown Ruby: 2.1.1
```

I'm not too familiar with what would be the difference between running `bash` directly vs `env - bash`. But since it's in there, I'm hoping you can provide some insight. :smile:
