### PR TITLE
Expose env vars to bash startup scripts

### DIFF
--- a/share/chruby/chruby.fish
+++ b/share/chruby/chruby.fish
@@ -44,14 +44,14 @@ function bchruby
   end
 
   set bash_path (echo $PATH | tr ' ' ':')
-  env - bash -lc "export HOME=$HOME           \
-                         PREFIX=$PREFIX       \
-                         PATH=$bash_path      \
-                         RUBY_ROOT=$RUBY_ROOT \
-                         GEM_HOME=$GEM_HOME   \
-                         GEM_ROOT=$GEM_ROOT   \
-                         GEM_PATH=$GEM_PATH;  \
-                  source $CHRUBY_ROOT/share/chruby/chruby.sh; $argv"
+  env - HOME=$HOME           \
+        PREFIX=$PREFIX       \
+        PATH=$bash_path      \
+        RUBY_ROOT=$RUBY_ROOT \
+        GEM_HOME=$GEM_HOME   \
+        GEM_ROOT=$GEM_ROOT   \
+        GEM_PATH=$GEM_PATH   \
+        bash -lc "source $CHRUBY_ROOT/share/chruby/chruby.sh; $argv"
 end
 
 # Define RUBIES variable with paths to installed ruby versions.


### PR DESCRIPTION
Because you're invoking `bash -l`, login scripts run. These can depend on variables like `$PATH` or `$HOME`.

This change moves the variable export outside of the `bash` invocation (but still inside of the `env` invocation) so that start up scripts operate correctly.
