### PR TITLE
Fix handeling PATH components with spaces

### DIFF
--- a/share/chruby/auto.fish
+++ b/share/chruby/auto.fish
@@ -62,7 +62,7 @@ function chruby_auto -e fish_prompt
   # RUBY_AUTO_VERSION, so we return quickly.
   #
   if test "$ch_ruby_auto_version" != "$RUBY_AUTO_VERSION"
-    set -gx RUBY_AUTO_VERSION $ch_ruby_auto_version
+    set -gx RUBY_AUTO_VERSION "$ch_ruby_auto_version"
 
     if test -n "$RUBY_AUTO_VERSION"
       chruby "$RUBY_AUTO_VERSION"

--- a/share/chruby/chruby.fish
+++ b/share/chruby/chruby.fish
@@ -43,7 +43,7 @@ function bchruby
     return 1
   end
 
-  set bash_path (echo $PATH | tr ' ' ':')
+  set bash_path (env | grep '^PATH=' | cut -c 6-)
   env - HOME=$HOME           \
         PREFIX=$PREFIX       \
         PATH=$bash_path      \
@@ -68,7 +68,8 @@ set -gx CHRUBY_VERSION (bchruby 'echo $CHRUBY_VERSION')
 # environment variables, returning the ruby version to the system default.
 #
 function chruby_reset
-  bchruby 'chruby_reset; echo $PATH ${GEM_PATH:-_}' | \
+  set -l IFS ";"
+  bchruby 'chruby_reset; echo "$PATH;${GEM_PATH:-_}"' | \
     read -l ch_path ch_gem_path
 
   if test (id -u) != '0'
@@ -96,9 +97,9 @@ end
 # variables and setting them in the current Fish instance.
 #
 function chruby_use
-  set -l args '; echo $RUBY_ROOT ${RUBYOPT:-_} ${GEM_HOME:-_} ${GEM_PATH:-_} \
-                      ${GEM_ROOT:-_} $PATH $RUBY_ENGINE $RUBY_VERSION $?'
+  set -l args '; echo "$RUBY_ROOT;${RUBYOPT:-_};${GEM_HOME:-_};${GEM_PATH:-_};${GEM_ROOT:-_};$PATH;$RUBY_ENGINE;$RUBY_VERSION;$?"'
 
+  set -l IFS ";"
   bchruby 'chruby_use' $argv $args | read -l ch_ruby_root ch_rubyopt ch_gem_home \
                                          ch_gem_path ch_gem_root ch_path \
                                          ch_ruby_engine ch_ruby_version \

--- a/share/chruby/chruby.fish
+++ b/share/chruby/chruby.fish
@@ -44,14 +44,14 @@ function bchruby
   end
 
   set bash_path (env | grep '^PATH=' | cut -c 6-)
-  env - HOME=$HOME           \
-        PREFIX=$PREFIX       \
-        PATH=$bash_path      \
-        RUBY_ROOT=$RUBY_ROOT \
-        GEM_HOME=$GEM_HOME   \
-        GEM_ROOT=$GEM_ROOT   \
-        GEM_PATH=$GEM_PATH   \
-        bash -lc "source $CHRUBY_ROOT/share/chruby/chruby.sh; $argv"
+  env - HOME="$HOME"           \
+        PREFIX="$PREFIX"       \
+        PATH="$bash_path"      \
+        RUBY_ROOT="$RUBY_ROOT" \
+        GEM_HOME="$GEM_HOME"   \
+        GEM_ROOT="$GEM_ROOT"   \
+        GEM_PATH="$GEM_PATH"   \
+        bash -lc "source \"$CHRUBY_ROOT/share/chruby/chruby.sh\"; $argv"
 end
 
 # Define RUBIES variable with paths to installed ruby versions.
@@ -78,7 +78,7 @@ function chruby_reset
     if test "$ch_gem_path" = '_'
       set -e GEM_PATH
     else
-      set -gx GEM_PATH $ch_gem_path
+      set -gx GEM_PATH "$ch_gem_path"
     end
   end
 
@@ -108,12 +108,12 @@ function chruby_use
   test "$ch_status" = 0; or return 1
   test -n "$RUBY_ROOT"; and chruby_reset
 
-  set -gx RUBY_ENGINE $ch_ruby_engine
-  set -gx RUBY_VERSION $ch_ruby_version
+  set -gx RUBY_ENGINE "$ch_ruby_engine"
+  set -gx RUBY_VERSION "$ch_ruby_version"
 
   set -gx RUBY_ROOT $ch_ruby_root
-  test $ch_gem_root = '_'; or set -gx GEM_ROOT $ch_gem_root
-  test $ch_rubyopt = '_'; or set -gx RUBYOPT $ch_rubyopt
+  test "$ch_gem_root" = '_'; or set -gx GEM_ROOT "$ch_gem_root"
+  test "$ch_rubyopt" = '_'; or set -gx RUBYOPT "$ch_rubyopt"
 
   # Fish warns the user when a path in the PATH environment variable does not
   # exist:
@@ -124,15 +124,15 @@ function chruby_use
   # Given that this happens for every Ruby install (until gems are installed in
   # these paths), we pre-create this directory, to silence Fish' warning.
   #
-  for gem_path in (echo $ch_gem_path | tr : '\n')
+  for gem_path in (echo "$ch_gem_path" | tr : '\n')
     test -d "$gem_path/bin"; or mkdir -p "$gem_path/bin"
   end
 
-  set -gx PATH (echo $ch_path | tr : '\n')
+  set -gx PATH (echo "$ch_path" | tr : '\n')
 
   if test (id -u) != '0'
-    set -gx GEM_HOME $ch_gem_home
-    set -gx GEM_PATH $ch_gem_path
+    set -gx GEM_HOME "$ch_gem_home"
+    set -gx GEM_PATH "$ch_gem_path"
   end
 end
 

--- a/test/home/.config/fish/config.fish
+++ b/test/home/.config/fish/config.fish
@@ -1,4 +1,4 @@
 set -gx original_path $PATH
-set -gx PATH $PATH /usr/local/bin /usr/bin /usr/sbin /bin /sbin
+set -gx PATH $PATH /usr/local/bin /usr/bin /usr/sbin /bin /sbin "$PWD/test/home/path with spaces"
 
 . $PWD/test/helper.fish


### PR DESCRIPTION
This fixes a problem when an element of the `PATH` environment variable contains a space.
Fixes #33 