### PR TITLE
Don't clutter PATH with bash initialisation

### DIFF
--- a/share/chruby/chruby.fish
+++ b/share/chruby/chruby.fish
@@ -51,7 +51,7 @@ function bchruby
         GEM_HOME="$GEM_HOME"   \
         GEM_ROOT="$GEM_ROOT"   \
         GEM_PATH="$GEM_PATH"   \
-        bash -lc "source \"$CHRUBY_ROOT/share/chruby/chruby.sh\"; $argv"
+        bash -c "source \"$CHRUBY_ROOT/share/chruby/chruby.sh\"; $argv"
 end
 
 # Define RUBIES variable with paths to installed ruby versions.


### PR DESCRIPTION
Passing `-l` to bash enables all path manipulations from the bash
initialisation chain (`/etc/profile`, `/etc/bashrc`, `~/.bash_profile`,
`~/.bash_login`, `~/.profile`, `~/.bashrc`, etc.) to bleed through to
the fish shell. In order to avoid that, we should simply execute
`chruby.sh` without their influence.