### PR TITLE
pass LD_LIBRARY_PATH to the child shell

### DIFF
--- a/share/chruby/chruby.fish
+++ b/share/chruby/chruby.fish
@@ -48,6 +48,7 @@ function bchruby
         PREFIX="$PREFIX"       \
         PATH="$bash_path"      \
         RUBY_ROOT="$RUBY_ROOT" \
+        LD_LIBRARY_PATH="$LD_LIBRARY_PATH" \
         GEM_HOME="$GEM_HOME"   \
         GEM_ROOT="$GEM_ROOT"   \
         GEM_PATH="$GEM_PATH"   \


### PR DESCRIPTION
Hi,

I've made a custom compiled Ruby like this:

```
#!/usr/bin/fish

begin
  set -lx optflags '-O3 -DNDEBUG'
  set -lx debugflags '-ggdb'
  set -lx cflags '-I /home/aaron/.jemalloc/include'
  set -lx CPPFLAGS '-I /home/aaron/.jemalloc/include'
  set -lx LDFLAGS '-L /home/aaron/.jemalloc/lib'
  set -lx LIBS '-ljemalloc'
  ./configure --prefix=/home/aaron/.rubies/ruby-trunk --disable-install-doc --with-jemalloc
end
```

It forces my Ruby to point at jemalloc installed in `/home/aaron/.jemalloc/lib`.  I set `LD_LIBRARY_PATH` to point at `/home/aaron/.jemalloc/lib`, but when I try to switch Rubys, I get an error:

```
aaron@whiteclaw ~ [1]> echo $LD_LIBRARY_PATH
/home/aaron/.jemalloc/lib
aaron@whiteclaw ~> chruby ruby-trunk
/home/aaron/.rubies/ruby-trunk/bin/ruby: error while loading shared libraries: libjemalloc.so.2: cannot open shared object file: No such file or directory
```

`ldd` finds jemalloc correctly because the environment variable is set:

```
aaron@whiteclaw ~ [1]> ldd /home/aaron/.rubies/ruby-trunk/bin/ruby
	linux-vdso.so.1 (0x00007ffe9b66a000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f1045302000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f10452df000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f10452d4000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f10452ce000)
	libcrypt.so.1 => /lib/x86_64-linux-gnu/libcrypt.so.1 (0x00007f1045293000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f1045144000)
	libjemalloc.so.2 => /home/aaron/.jemalloc/lib/libjemalloc.so.2 (0x00007f1044dea000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f1044bf8000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f104572a000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f1044a17000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f10449fc000)
```

But since `LD_LIBRARY_PATH` isn't passed down to bash when switching Ruby, I get an error saying that libjemalloc can't be found.  This commit passes LD_LIBRARY_PATH to the child process so that I can switch versions.

I did this on Linux, but I suspect MacOS will have the same problem but need a different environment variable (I haven't tested though).