### PR TITLE
Expand 'set -l', as it takes one arg only

### DIFF
--- a/share/chruby/chruby.fish
+++ b/share/chruby/chruby.fish
@@ -155,7 +155,9 @@ function chruby
       if test "$argv[1]" = ''
         bchruby "chruby $argv"
       else
-        set -l dir ruby match
+        set -l dir
+        set -l ruby
+        set -l match
         for dir in $RUBIES
           set dir (echo "$dir" | sed -e 's|/$||')
           set ruby (echo "$dir" | awk -F/ '{print $NF}')


### PR DESCRIPTION
Verified that in fish version 3.2.2, "set -l dir ruby match" sets $dir to [ruby match], which doesn't seem to be the intention.