### PR TITLE
Don't set RUBIES as a global

### DIFF
--- a/share/fish/vendor_functions.d/chruby.fish
+++ b/share/fish/vendor_functions.d/chruby.fish
@@ -1,7 +1,12 @@
 set -g CHRUBY_VERSION '1.0.0'
-set -g RUBIES $HOME/.rubies/* $PREFIX/opt/rubies/*
 
 function chruby -a ruby_version
+    if not set -q RUBIES_DIR
+      set RUBIES_DIR $HOME/.rubies
+    end
+
+    set RUBIES $RUBIES_DIR/* $PREFIX/opt/rubies/*
+
     switch "$ruby_version"
         case '-h' '--help'
             echo "usage: chruby [RUBY|VERSION|system] [RUBYOPT...]"


### PR DESCRIPTION
This commit doesn't set RUBIES as a global.  This means you don't need
to restart your shell to pick up newly installed Ruby versions.  This
commit also uses a `RUBIES_DIR` prefix variable.  When `RUBIES_DIR` is
not set, it just defaults to `$HOME/.rubies`.

I use this environment variable so that I can have separate
installations for ARM64 and x86_64 versions of Ruby.  Observe the
following excerpt from my fish configuration:

```
set -g RUBIES_DIR $HOME/.rubies/(arch)
```

It sets the `RUBIES_DIR` based on the current architecture.  If I'm
using arm64 on my M1, then `RUBIES_DIR` will be `$HOME/.rubies/arm64`
and chruby will find only my arm64 installations of Ruby.  If I'm
running under Rosetta, `arch` will return "i386" and chruby will search
under `$HOME/.rubies/i386` and only pick up Rubys that have been
compiled with x86 support.

To complete the example, I also have this in my fish config:

```
if test (arch) = "i386"
  set HOMEBREW_PREFIX /usr/local
else
  set HOMEBREW_PREFIX /opt/homebrew
end

fish_add_path -m --path $HOMEBREW_PREFIX/bin

alias intel 'arch -x86_64 /usr/local/bin/fish'
```

I have Intel homebrew installed in `/usr/local` and arm64 homebrew in
`/opt/homebrew`.  The top few lines ensure that the correct `brew`
command is always available depending on my current architecture. The
last line adds an alias that starts Fish under rosetta.  This allows me
to do:

```
[aaron@Aarons-MacBook-Pro💪 ~/g/chruby-fish (no-global)]$ arch
arm64
[aaron@Aarons-MacBook-Pro💪 ~/g/chruby-fish (no-global)]$ intel
Welcome to fish, the friendly interactive shell
[aaron@Aarons-MacBook-Pro🧐 ~/g/chruby-fish (no-global)]$ arch
i386
[aaron@Aarons-MacBook-Pro🧐 ~/g/chruby-fish (no-global)]$ exit
[aaron@Aarons-MacBook-Pro💪 ~/g/chruby-fish (no-global)]$ arch
arm64
[aaron@Aarons-MacBook-Pro💪 ~/g/chruby-fish (no-global)]$
```